### PR TITLE
Added option to change Port Number along with the input ip address

### DIFF
--- a/phonesploitpro.py
+++ b/phonesploitpro.py
@@ -150,6 +150,7 @@ def connect():
     # Connect only 1 device at a time
     print(
         f"\n{color.CYAN}Enter target phone's IP Address       {color.YELLOW}Example : 192.168.1.23{color.WHITE}"
+        f"\n{color.CYAN}Enter target phone's IP Address with Specific Port Number\n{color.YELLOW}Example : 192.168.1.23:5555{color.WHITE}"
     )
     ip = input("> ")
     if ip == "":

--- a/phonesploitpro.py
+++ b/phonesploitpro.py
@@ -163,7 +163,7 @@ def connect():
             os.system(
                 "adb kill-server > docs/hidden.txt 2>&1&&adb start-server > docs/hidden.txt 2>&1"
             )
-            os.system("adb connect " + ip + ":5555")
+            os.system("adb connect " + ip )
         else:
             print(
                 f"\n{color.RED} Invalid IP Address\n{color.GREEN} Going back to Main Menu{color.WHITE}"

--- a/phonesploitpro.py
+++ b/phonesploitpro.py
@@ -148,8 +148,7 @@ def change_page(name):
 
 def connect():
     # Connect only 1 device at a time
-    print(
-        f"\n{color.CYAN}Enter target phone's IP Address       {color.YELLOW}Example : 192.168.1.23{color.WHITE}"
+    print(
         f"\n{color.CYAN}Enter target phone's IP Address with Specific Port Number\n{color.YELLOW}Example : 192.168.1.23:5555{color.WHITE}"
     )
     ip = input("> ")


### PR DESCRIPTION
As Android generates random port number for wireless debugging, the _default port 5555_ becomes unusable for some users, i now modified the code to enter the **port number along with the IP address**, i have also attached the screenshot of an android device which generates random port number everytime.
![Attachment](https://github.com/AzeemIdrisi/PhoneSploit-Pro/assets/73155306/baf4f4e7-184b-4445-812d-4e949a191c65)
